### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ pyJunosManager
 Making Junos management trivial
 
 [![Documentation Status](https://readthedocs.org/projects/pyjunosmanager/badge/?version=latest)](https://readthedocs.org/projects/pyjunosmanager/?badge=latest)
-[![Latest Version](https://pypip.in/version/pyjunosmanager/badge.svg)](https://pypi.python.org/pypi/pyjunosmanager/)
+[![Latest Version](https://img.shields.io/pypi/v/pyjunosmanager.svg)](https://pypi.python.org/pypi/pyjunosmanager/)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyjunosmanager))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyjunosmanager`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.